### PR TITLE
Fix typo and add enscript to the list

### DIFF
--- a/configs/sst_cs_infra_services-printing-stack.yaml
+++ b/configs/sst_cs_infra_services-printing-stack.yaml
@@ -2,7 +2,7 @@ document: feedback-pipeline-workload
 version: 1
 data:
   name: Printing Stack
-  description: Suite of software needed for priting on Linux
+  description: Suite of software needed for printing on Linux
   maintainer: sst_cs_infra_services
 
   packages:
@@ -12,6 +12,7 @@ data:
   - cups-filters
   - cups-ipptool
   - cups-lpd
+  - enscript
   - foomatic
   - foomatic-db
   - ghostscript


### PR DESCRIPTION
Enscript can be required explicitly by customer for file conversion.